### PR TITLE
Add .gitattribute files to ensure shell scripts are cloned with the correct EOL on windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/deployment/.gitattributes
+++ b/deployment/.gitattributes
@@ -1,0 +1,1 @@
+docker-proxy text eol=lf


### PR DESCRIPTION
Without this shell scripts (and `deployment/docker-proxy`) are cloned with `CRLF` on windows.