### PR TITLE
Fix usage of `actions/*-artifacts@v4` in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: dist
+          name: dist-base
           path: dist
   
   build-windows:
@@ -143,8 +143,9 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
-          name: dist
+          pattern: dist-*
           path: dist
+          merge-multiple: true
 
       - name: Setup dotnet SDK
         uses: actions/setup-dotnet@v4
@@ -173,7 +174,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: dist
+          name: dist-installer
           path: dist-installer
 
   release:
@@ -197,8 +198,9 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
-          name: dist
+          pattern: dist-*
           path: dist
+          merge-multiple: true
 
       - name: Create hashes
         shell: bash
@@ -215,14 +217,3 @@ jobs:
             dist/ContainerDesktopInstaller.exe
             dist/ContainerDesktopInstaller.zip
             dist/sha256sum.txt
-      
-
-        
-
-      
-
-
-          
-      
-      
-      


### PR DESCRIPTION
## Summary of the Pull Request

It appear that the behaviour of the `upload-artifact` action was changed between `v3` and `v4` and that implicitly merging content by invoking the `upload-artifact` action with the same artifact name and different paths is not supported anymore.
This PR attempt to resolve the issue by applying the changes suggested in https://github.com/actions/upload-artifact/issues/480#issuecomment-1937762859

Related
- https://github.com/actions/upload-artifact/issues/480
- https://github.com/actions/download-artifact#download-multiple-filtered-artifacts-to-the-same-directory


