### PR TITLE
Enhance volume path mount rewriter to support any arbitrary wsl distribution paths

### DIFF
--- a/cmd/container-desktop-proxy/main.go
+++ b/cmd/container-desktop-proxy/main.go
@@ -76,7 +76,7 @@ var rootCmd = &cobra.Command{
 		proxy.Director = func(r *http.Request) {
 			orgDirector(r)
 			logger.Debugf("Requesting url: %s: %s", r.Method, r.URL)
-			body, err := rewrite.RewriteBody(r.Body, r.URL.Path, flags.wslDistroName, logger)
+			body, err := rewrite.RewriteBody(r.Body, r.URL.Path, flags.wslDistroName, logger, rewrite.Request)
 			if len(body) > 0 && err == nil {
 				logger.Debug("Request body was rewritten")
 				r.Body = io.NopCloser(bytes.NewReader(body))
@@ -85,7 +85,7 @@ var rootCmd = &cobra.Command{
 		}
 		proxy.ModifyResponse = func(r *http.Response) error {
 			logger.Debugf("Original response content-length: %d", r.ContentLength)
-			body, err := rewrite.RewriteBody(r.Body, r.Request.URL.Path, flags.wslDistroName, logger)
+			body, err := rewrite.RewriteBody(r.Body, r.Request.URL.Path, flags.wslDistroName, logger, rewrite.Response)
 			if err != nil {
 				return err
 			}

--- a/internal/rewrite/rewrite.go
+++ b/internal/rewrite/rewrite.go
@@ -1,6 +1,7 @@
 package rewrite
 
 import (
+	"fmt"
 	"encoding/json"
 	"io"
 	"regexp"
@@ -11,10 +12,38 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
+type RewriteType int
+
+// Indicate if the mapping need to translate between the 
+// client file system and the docker daemon host file system 
+// (rewriteType: Request) or vice versa (rewriteType: Response)
+const (
+	Request RewriteType = iota + 1 // EnumIndex = 1
+	Response
+)
+type rewriteContext struct {
+	// logger
+	logger *zap.SugaredLogger
+	// The base virtual mapping mount folder that
+	// provide access either to the host or to the 
+	// local WSL distro file system.
+	// Can be either:
+	// Windows: /mnt/distro 
+	// Linux  : /mnt/wsl/{wsl_distro} (e.g. /mnt/wsl/{Ubuntu})
+	path string
+	// Indicate if the mapping need to translate between the 
+	// client file system and the docker daemon host file system 
+	// (rewriteType: Request) or vice versa (rewriteType: Response)
+	rewriteType RewriteType
+	// Indicate if the proxy is running on Windows (note that
+	// `isWindow == true IMPLY THAT host == '/mnt/distro'`)
+	isWindows bool
+}
+
 type rewriteMapItem struct {
 	method   string
 	pattern  string
-	rewriter func(map[string]interface{}, string)
+	rewriter func(map[string]interface{}, *rewriteContext)
 }
 
 var rewriteMappings = []rewriteMapItem{
@@ -30,7 +59,7 @@ func enabled(logger *zap.SugaredLogger, level zapcore.Level) bool {
 	return logger.Desugar().Core().Enabled(level)
 }
 
-func RewriteBody(body io.ReadCloser, urlPath string, wslDistroName string, logger *zap.SugaredLogger) (rewrittenBody []byte, err error) {
+func RewriteBody(body io.ReadCloser, urlPath string, wslDistroName string, logger *zap.SugaredLogger, rewriteType RewriteType) (rewrittenBody []byte, err error) {
 	if body != nil {
 		rewriter, ok := getRewriter(urlPath)
 		if ok {
@@ -74,7 +103,8 @@ func RewriteBody(body io.ReadCloser, urlPath string, wslDistroName string, logge
 				for _, item := range jsonArray {
 					m, ok := item.(map[string]interface{})
 					if ok {
-						rewriter(m, path)
+						ctx := &rewriteContext{ logger: logger, path: path, rewriteType: rewriteType, isWindows: rt.GOOS == "windows" }
+						rewriter(m, ctx)
 					}
 				}
 				if isArray {
@@ -96,7 +126,7 @@ func RewriteBody(body io.ReadCloser, urlPath string, wslDistroName string, logge
 	return nil, nil
 }
 
-func getRewriter(urlPath string) (func(map[string]interface{}, string), bool) {
+func getRewriter(urlPath string) (func(map[string]interface{}, *rewriteContext), bool) {
 	for _, item := range rewriteMappings {
 		ok, err := regexp.MatchString(item.pattern, urlPath)
 		if err == nil && ok {
@@ -106,98 +136,98 @@ func getRewriter(urlPath string) (func(map[string]interface{}, string), bool) {
 	return nil, false
 }
 
-func rewriteContainerSummary(jsonMap map[string]interface{}, path string) {
+func rewriteContainerSummary(jsonMap map[string]interface{}, context *rewriteContext) {
 	o, ok := jsonMap["HostConfig"]
 	if ok {
 		hostConfig, ok := o.(map[string]interface{})
 		if ok {
-			rewriteHostConfig(hostConfig, path)
+			rewriteHostConfig(hostConfig, context)
 		}
 	}
 	o, ok = jsonMap["Mounts"]
 	if ok {
 		mounts, ok := o.([]interface{})
 		if ok {
-			rewriteMounts(mounts, path)
+			rewriteMounts(mounts, context)
 		}
 	}
 }
 
-func rewriteContainerConfig(jsonMap map[string]interface{}, path string) {
+func rewriteContainerConfig(jsonMap map[string]interface{}, context *rewriteContext) {
 	o, ok := jsonMap["HostConfig"]
 	if ok {
 		hostConfig, ok := o.(map[string]interface{})
 		if ok {
-			rewriteHostConfig(hostConfig, path)
+			rewriteHostConfig(hostConfig, context)
 		}
 	}
 	o, ok = jsonMap["Mounts"]
 	if ok {
 		mounts, ok := o.([]interface{})
 		if ok {
-			rewriteMounts(mounts, path)
+			rewriteMounts(mounts, context)
 		}
 	}
 }
 
-func rewriteService(jsonMap map[string]interface{}, path string) {
+func rewriteService(jsonMap map[string]interface{}, context *rewriteContext) {
 	o, ok := jsonMap["Spec"]
 	if ok {
 		spec, ok := o.(map[string]interface{})
 		if ok {
-			rewriteServiceSpec(spec, path)
+			rewriteServiceSpec(spec, context)
 		}
 	}
 }
 
-func rewriteServiceSpec(jsonMap map[string]interface{}, path string) {
+func rewriteServiceSpec(jsonMap map[string]interface{}, context *rewriteContext) {
 	o, ok := jsonMap["TaskTemplate"]
 	if ok {
 		taskSpec, ok := o.(map[string]interface{})
 		if ok {
-			rewriteTaskSpec(taskSpec, path)
+			rewriteTaskSpec(taskSpec, context)
 		}
 	}
 }
 
-func rewriteTaskSpec(jsonMap map[string]interface{}, path string) {
+func rewriteTaskSpec(jsonMap map[string]interface{}, context *rewriteContext) {
 	o, ok := jsonMap["ContainerSpec"]
 	if ok {
 		containerSpec, ok := o.(map[string]interface{})
 		if ok {
-			rewriteContainerSpec(containerSpec, path)
+			rewriteContainerSpec(containerSpec, context)
 		}
 	}
 }
 
-func rewriteContainerSpec(jsonMap map[string]interface{}, path string) {
+func rewriteContainerSpec(jsonMap map[string]interface{}, context *rewriteContext) {
 	o, ok := jsonMap["Mounts"]
 	if ok {
 		mounts, ok := o.([]interface{})
 		if ok {
-			rewriteMounts(mounts, path)
+			rewriteMounts(mounts, context)
 		}
 	}
 }
 
-func rewriteTask(jsonMap map[string]interface{}, path string) {
+func rewriteTask(jsonMap map[string]interface{}, context *rewriteContext) {
 	o, ok := jsonMap["Spec"]
 	if ok {
 		taskSpec, ok := o.(map[string]interface{})
 		if ok {
-			rewriteTaskSpec(taskSpec, path)
+			rewriteTaskSpec(taskSpec, context)
 		}
 	}
 }
 
-func rewriteHostConfig(hostConfig map[string]interface{}, path string) {
+func rewriteHostConfig(hostConfig map[string]interface{}, context *rewriteContext) {
 	o, ok := hostConfig["Binds"]
 	if ok {
 		binds, ok := o.([]interface{})
 		if ok {
 			for i, bind := range binds {
 				s := bind.(string)
-				s = mapPath(s, path)
+				s = mapPath(s, context)
 				binds[i] = s
 			}
 		}
@@ -206,27 +236,40 @@ func rewriteHostConfig(hostConfig map[string]interface{}, path string) {
 	if ok {
 		mounts, ok := o.([]interface{})
 		if ok {
-			rewriteMounts(mounts, path)
+			rewriteMounts(mounts, context)
 		}
 	}
 }
 
-func rewriteMounts(mounts []interface{}, path string) {
+func rewriteMounts(mounts []interface{}, context *rewriteContext) {
 	for _, o := range mounts {
 		mount, ok := o.(map[string]interface{})
 		if ok {
 			t := mount["Type"].(string)
 			if t == "bind" {
 				s := mount["Source"].(string)
-				s = mapPath(s, path)
+				s = mapPath(s, context)
 				mount["Source"] = s
 			}
 		}
 	}
 }
 
-func mapPath(s string, path string) string {
-	s = strings.Replace(s, "\\", "/", -1)
+func mapPath(binding string, context *rewriteContext) string {
+
+	if context != nil {
+		return mapPathV2(binding, context)
+	}
+
+	rtype := "REQ"
+	if context.rewriteType == Response {
+		rtype = "RSP"
+	}
+    path := context.path
+    logger := context.logger
+	lctx := fmt.Sprintf("[mapPath2(type: %8s, win: %v, binding: %40s, base: %10s)]", rtype, context.isWindows, binding, path)
+	
+	s := strings.Replace(binding, "\\", "/", -1)
 	parts := strings.Split(s, ":")
 	if strings.HasPrefix(parts[0], "/mnt/host/") {
 		p := parts[0][10:]
@@ -246,5 +289,161 @@ func mapPath(s string, path string) string {
 	} else if strings.HasPrefix(s, "/") {
 		s = path + s
 	}
+	logger.Warnf("%s ==> %-40s", lctx, s)
 	return s
 }
+
+// Map a docker container volume bind expression between the WSL host
+// context (e.g. '/mnt/host' on windows, or mnt/wsl/{distro_name} when
+// the proxy is running in a WSL linux distribution) from which the 
+// client is run and the host where the  docker daemon is running.
+// s: container volume bind expression (e.g. {host_path}:{container_path})
+// rewriteContext: provide contextual information about the client hosting 
+// context.
+func mapPathV2(binding string, context *rewriteContext) string {
+	// "%s Request  %40s ==> [%10s] ==> %-40s", lctx, original, path, s
+	rtype := "REQ"
+	if context.rewriteType == Response {
+		rtype = "RSP"
+	}
+    path := context.path
+    logger := context.logger
+	lctx := fmt.Sprintf("[mapPath2(type: %8s, win: %v, binding: %40s, base: %10s)]", rtype, context.isWindows, binding, path)
+
+	// Before we normalize the slash in the path,
+	// handle resources that are on the host 
+	// and are not replicated through mounts
+	// (e.g. //var/run/docker.sock)
+	if strings.HasPrefix(binding, "//") {
+		// Log the mapping result
+		logger.Warnf("%s ==> %-40s", lctx, binding)
+		return binding
+	}
+
+    s := strings.Replace(binding, "\\", "/", -1)
+    parts := strings.Split(s, ":")
+    clientPath := parts[0]
+
+	getUnixPath := func(base string, pathSegments ...string) string {
+		x := append([]string{base}, pathSegments...)
+		return strings.Join(x, "/")
+    }
+	getMountPath := func(pathSegments ...string) string {
+		return getUnixPath("/mnt", pathSegments...)
+    }
+	getHostMountPath := func(pathSegments ...string) string {
+		return getUnixPath("/mnt/host", pathSegments...)
+    }
+	getWslPath := func(pathSegments ...string) string {
+		return getUnixPath("/mnt/wsl", pathSegments...)
+    }
+	translateToWindowsPath := func(linuxPath string) string {
+		return strings.Replace(linuxPath, "/", "\\", -1)
+	}
+
+    if strings.HasPrefix(clientPath, "/mnt/") {
+        // Handle paths starting with /mnt/
+        mntPath := clientPath[5:]
+        allPathSegments := strings.Split(mntPath, "/")
+        mntType := allPathSegments[0]
+        pathSegments := allPathSegments[1:]
+
+        switch mntType {
+        case "host":
+			if len(pathSegments) == 0 {
+				logger.Errorf("%s Invalid binding. Expected at least one path segment.", lctx)
+				parts[0] = ""
+				break;
+			}
+            // Handle host paths
+			
+            if context.isWindows {
+				// Host proxy on Windows
+				drive := pathSegments[0]
+				drivePath := strings.Join(pathSegments[1:], "/")
+				// winpath => {drive}:/some/path
+				winpath := drive + ":/" + drivePath
+				// parts[0] => {drive}:\some\path
+				parts[0] = translateToWindowsPath(winpath)
+            } else {
+				// either a socket or a unix path
+				// Distro proxy on WSL
+				parts[0] = getMountPath(pathSegments...)
+            }
+        case "wsl":
+            // Handle WSL paths
+            distro := pathSegments[0]
+            if context.isWindows && context.rewriteType == Response {
+                // Host proxy on Windows
+				res := getUnixPath("//wsl.localhost", pathSegments...)
+                parts[0] = translateToWindowsPath(res)
+            } else {
+                // Distro proxy on WSL
+                if context.rewriteType == Response && path == getWslPath(distro) {
+					// When a request is coming from the local WSL distro
+					// parts[0] => /some/path
+					parts[0] = getUnixPath("", pathSegments[1:]...)
+                } else {
+					parts[0] = getWslPath(pathSegments...)
+                }
+            }
+        default:
+            if context.rewriteType == Request {
+				parts[0] = getHostMountPath(allPathSegments...)
+            } else {
+                logger.Warnf("%s Don't know how to map mount type %s (type: %s) for response ", lctx, parts[0], mntType)
+            }
+        }
+        s = strings.Join(parts, ":")
+    } else if context.isWindows {
+		// Handle Windows paths
+
+		// strip windows UNC prefix (case insensitive)
+		wslPath := strings.ToLower(clientPath)
+		if strings.HasPrefix(clientPath, "//wsl.localhost/") {
+			wslPath = clientPath[16:]
+		} else if strings.HasPrefix(clientPath, "//wsl$/") {
+			wslPath = clientPath[7:]
+		}
+        // Check if we found either prefixes by comparing
+		// with the length of the original value
+        if len(wslPath) != len(clientPath)  {
+            // Map as /wsl/{distro}/{wslPath}
+            parts[0] = getWslPath(wslPath)
+            s = strings.Join(parts, ":")
+        } else if len(clientPath) == 1 {
+			// Handle REQUESTS that contains host paths on 
+			// the windows proxy.
+
+			// This can only be a request because we always
+			// map windows paths to /mnt/host/{path}
+			// so for responses we should go through the
+			// first leg.
+
+			// ASSERT(context.rewriteType == Request)
+			
+			// At this point parts should be something like 
+			// => [{drive == clientPath}, {path}, {containerPath}]
+			drive := strings.ToLower(parts[0])
+
+			// s => /mnt/host/{drive}/some/path:/{containerPath}
+			s = path + "/" + drive + strings.Join(parts[1:], ":")
+		} else {
+			// Handle other Windows paths
+			parts[0] = translateToWindowsPath(clientPath)
+			s = strings.Join(parts, ":")
+		}
+    } else if strings.HasPrefix(s, "/") {
+        // Handle Linux paths
+		// This could result in either a mapping 
+		// to the mount of the WSL distro OR
+		// the mount of the host path
+        s = path + s
+    }
+
+    // Log the mapping result
+    logger.Warnf("%s ==> %-40s", lctx, s)
+
+    return s
+}
+

--- a/internal/rewrite/rewrite_test.go
+++ b/internal/rewrite/rewrite_test.go
@@ -1,0 +1,76 @@
+package rewrite
+
+import (
+	"testing"
+	"go.uber.org/zap/zaptest"
+)
+
+func runTest(t *testing.T, rewriteType RewriteType, wslDistroName string, mount string, expected string) string {
+	logger := zaptest.NewLogger(t).Sugar()
+	path := "/mnt/host"
+	if wslDistroName != "" {
+		path = "/mnt/wsl/" + wslDistroName
+	}
+	ctx := rewriteContext{ logger: logger, path: path, rewriteType: rewriteType, isWindows: wslDistroName == "" }
+	
+	mapping := mount+ ":/test"
+	
+	res := mapPath(mapping, &ctx)
+	expected +=":/test"
+	if res != expected  {
+		logger.Errorf("FAILED. %s != %s", res, expected)
+	}
+	return ""
+}
+
+func TestLinuxRequest(t *testing.T){
+
+	runTest(t, Request, "Ubuntu", "/", "/mnt/wsl/Ubuntu/")
+	runTest(t, Request, "Ubuntu", "/mnt/c", "/mnt/host/c")
+	runTest(t, Request, "Ubuntu", "/home/user", "/mnt/wsl/Ubuntu/home/user")
+	runTest(t, Request, "Alpine", "/mnt/wsl/Ubuntu/home/user", "/mnt/wsl/Ubuntu/home/user")
+	
+
+	runTest(t, Response, "Ubuntu", "/mnt/host/c", "/mnt/c")
+	// runTest(t, Response, "Ubuntu", "/mnt/host", "/mnt")
+	runTest(t, Response, "Ubuntu", "/mnt/wsl/Ubuntu/home/user", "/home/user")
+	runTest(t, Response, "Alpine", "/mnt/wsl/Ubuntu/home/user", "/mnt/wsl/Ubuntu/home/user")
+	
+
+}
+
+func TestWindowsRequest(t *testing.T){
+
+	runTest(t, Request, "", "C:\\users\\user", "/mnt/host/c/users/user")
+	runTest(t, Request, "", "C:\\Users\\User", "/mnt/host/c/Users/User")
+	runTest(t, Request, "", "\\\\wsl.localhost\\Ubuntu", "/mnt/wsl/Ubuntu") 
+	runTest(t, Request, "", "\\\\wsl.localhost\\Ubuntu\\", "/mnt/wsl/Ubuntu/") 
+	runTest(t, Request, "", "\\\\wsl.localhost\\Ubuntu\\user", "/mnt/wsl/Ubuntu/user") 
+	runTest(t, Request, "", "\\\\wsl.localhost\\Ubuntu\\user\\", "/mnt/wsl/Ubuntu/user/") 
+	runTest(t, Request, "", "\\\\wsl.localhost\\Ubuntu\\user\\home", "/mnt/wsl/Ubuntu/user/home") 
+	runTest(t, Request, "", "\\\\wsl.localhost\\Ubuntu\\User\\Home", "/mnt/wsl/Ubuntu/User/Home") 
+	runTest(t, Request, "", "\\\\wsl$\\Ubuntu\\user\\home", "/mnt/wsl/Ubuntu/user/home") 
+	runTest(t, Request, "", "\\\\wsl$\\Ubuntu\\User\\Home", "/mnt/wsl/Ubuntu/User/Home") 
+	runTest(t, Request, "", "/mnt/c", "/mnt/host/c") 
+	runTest(t, Request, "", "/mnt/wsl/Ubuntu/user/home", "/mnt/wsl/Ubuntu/user/home")
+	
+
+	runTest(t, Response, "", "/mnt/host/c", "c:\\") 
+	runTest(t, Response, "", "/mnt/host", "c:\\") 
+	runTest(t, Response, "", "/mnt/host/c/users/user", "c:\\users\\user") 
+	runTest(t, Response, "", "/mnt/wsl/Ubuntu", "\\\\wsl.localhost\\Ubuntu") 
+	runTest(t, Response, "", "/mnt/wsl/Ubuntu/", "\\\\wsl.localhost\\Ubuntu\\") 
+	runTest(t, Response, "", "/mnt/wsl/Ubuntu/user", "\\\\wsl.localhost\\Ubuntu\\user") 
+	runTest(t, Response, "", "/mnt/wsl/Ubuntu/user/", "\\\\wsl.localhost\\Ubuntu\\user\\") 
+	runTest(t, Response, "", "/mnt/wsl/Ubuntu/user/home", "\\\\wsl.localhost\\Ubuntu\\user\\home") 
+}
+
+func TestSocketMapping(t *testing.T){
+	
+	runTest(t, Request, "Ubuntu", "//var/run/docker.sock", "//var/run/docker.sock")
+	runTest(t, Response, "Ubuntu", "//var/run/docker.sock", "//var/run/docker.sock")
+
+	// Docker compatible
+	runTest(t, Request, "", "//var/run/docker.sock", "//var/run/docker.sock")
+	runTest(t, Response, "", "//var/run/docker.sock", "//var/run/docker.sock")
+}


### PR DESCRIPTION
## Summary of the Pull Request

Enhance volume path mount rewriter to support any arbitrary wsl distribution paths

## Pull Request Checklist

* [ ] Closes #xxx
* [x] Tests added/passed
* [ ] Documentation updated.

## Detailed Description of the Pull Request / Additional comments

Supported syntaxes:
- Host path (e.g. `c:\users\john`)
  - `{windrive}:\{path}` (.e.g `C:\users\user\john`)
  - `/mnt/host/{windrive}` (e.g. `/mnt/host/c`)
     > `/mnt/host` will also implicitly map to of `/mnt/host/c`
  - `/mnt/{windrive}/{path}` (e.g. `/mnt/c/users/john`)
- Distro path
  - `\\wsl.localhost\{distro}\{path}` (.e.g `\\wsl.localhost\Ubuntu\user\home`)
  - `\\wsl$\{distro}\{path}` (.e.g `\\wsl$\Ubuntu\user\home`)
  - `/mnt/wsl/{distro}/{path}` (e.g. `/mnt/wls/Ubuntu/user/home`)
- Domain socket
  - `//var/run/docker.sock` (this is the same syntax used by docker desktop)
