### PR TITLE
bash/ps1 scripts enhancements/fixes

### DIFF
--- a/deployment/docker-proxy
+++ b/deployment/docker-proxy
@@ -3,9 +3,11 @@ _term() {
   echo "C $cmd" | nc -N -U /var/run/cd-port-forward.sock
   kill -INT "$child" 2>/dev/null
 }
-trap _term SIGINT
+trap _term INT
+# shellcheck disable=SC2124
 cmd=$@
 echo "O $cmd" | nc -N -U /var/run/cd-port-forward.sock
+# shellcheck disable=SC2068
 docker-proxy-org $@ &
 child=$!
 wait "$child"

--- a/deployment/wsl-distro-init.sh
+++ b/deployment/wsl-distro-init.sh
@@ -1,7 +1,16 @@
 #!/bin/sh
 distro="${1:-$WSL_DISTRO_NAME}"
-mkdir -p /mnt/wsl/$distro
-mount --bind / /mnt/wsl/$distro
+
+# If mount point directory does not exist, create it.
+if [ ! -d "/mnt/wsl/$distro" ]; then
+    mkdir -p "/mnt/wsl/$distro"
+fi
+
+# If mount point directory is not mounted upon, bind mount fs.
+if ! mountpoint -q -- "/mnt/wsl/$distro"; then
+    mount --bind / "/mnt/wsl/$distro"
+fi
+
 mkdir -p /usr/libexec/docker
 if [ -d /usr/libexec/docker/cli-plugins ]; then
   rm -rf /usr/libexec/docker/cli-plugins

--- a/deployment/wsl-distro-rm.sh
+++ b/deployment/wsl-distro-rm.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-distro="${1:-$WSL_DISTRO_NAME}"
+# distro="${1:-$WSL_DISTRO_NAME}"
 pkill -f container-desktop-proxy
 readlink /usr/local/bin/docker-compose && unlink /usr/local/bin/docker-compose
 readlink /usr/local/bin/docker && unlink /usr/local/bin/docker

--- a/deployment/wsl-init.sh
+++ b/deployment/wsl-init.sh
@@ -3,13 +3,17 @@ mkdir -p /mnt/host/wsl/container-desktop/cli-tools
 mkdir -p /mnt/host/wsl/container-desktop/certs
 mkdir -p /mnt/host/wsl/container-desktop/proxy
 mkdir -p /mnt/host/wsl/container-desktop/distro
-mkdir -p /mnt/wsl
+if [ ! -d "/mnt/wsl" ]; then
+    mkdir -p /mnt/wsl
+fi
 mkdir -p /var/lib/docker
 mount --bind /usr/local/bin/cli-tools /mnt/host/wsl/container-desktop/cli-tools
 mount --bind /certs /mnt/host/wsl/container-desktop/certs
 mount --bind /proxy /mnt/host/wsl/container-desktop/proxy
 mount --bind /distro /mnt/host/wsl/container-desktop/distro
-mount --bind /mnt/host/wsl /mnt/wsl
+# IMPORTANT: this should be rbind (r => recursive)
+# so that it also share other 
+mount --rbind /mnt/host/wsl /mnt/wsl
 mount --bind /mnt/host/wsl/container-desktop-data/data /var/lib/docker
 mkdir -p /sys/fs/cgroup/systemd
 if ! mountpoint -q /sys/fs/cgroup/systemd; then


### PR DESCRIPTION
## Summary of the Pull Request

- Fix: Ensure bash EOL is `LF` and not `CRLF`
- Fix: Apply fixes reported by shellcheck
- Fix/Enhance: Check if target exists before creating a directory. This should not be necessary, but i had some random occourrence where the installation was failing because directories/mounts already exists  and this seems to have solved the issue.
- Enhance: Add some volume mapping to cache known build artifacts to speed up local builds (`build.ps1`)
