### PR TITLE
Ensure  proxy logs are available in the UI log stream.

### DIFF
--- a/container-desktop/ContainerDesktop/Services/DefaultContainerEngine.cs
+++ b/container-desktop/ContainerDesktop/Services/DefaultContainerEngine.cs
@@ -457,7 +457,7 @@ public sealed class DefaultContainerEngine : IContainerEngine, IDisposable
             .Add("--tls-cert", Path.Combine(LocalCertsPath, "cert.pem"), true)
             .Add("--tls-ca", Path.Combine(LocalCertsPath, "ca.pem"), true)
             .Build();
-        _proxyProcess = _processExecutor.Start(proxyPath, args);
+        _proxyProcess = _processExecutor.Start(proxyPath, args, stdOut: LogStdOut, stdErr: LogStdError);
         // Give it some time to startup
         if (_proxyProcess.WaitForExit(1000))
         {
@@ -568,6 +568,14 @@ public sealed class DefaultContainerEngine : IContainerEngine, IDisposable
         {
             _ = Task.Run(() => UpdateCertificates());
         }
+    }
+    private void LogStdOut(string s)
+    {
+        _logger.LogInformation(s);
+    }
+    private void LogStdError(string s)
+    {
+        _logger.LogInformation(s);
     }
 }
 

--- a/internal/rewrite/rewrite.go
+++ b/internal/rewrite/rewrite.go
@@ -289,7 +289,7 @@ func mapPath(binding string, context *rewriteContext) string {
 	} else if strings.HasPrefix(s, "/") {
 		s = path + s
 	}
-	logger.Warnf("%s ==> %-40s", lctx, s)
+	logger.Infof("%s ==> %-40s", lctx, s)
 	return s
 }
 
@@ -316,7 +316,7 @@ func mapPathV2(binding string, context *rewriteContext) string {
 	// (e.g. //var/run/docker.sock)
 	if strings.HasPrefix(binding, "//") {
 		// Log the mapping result
-		logger.Warnf("%s ==> %-40s", lctx, binding)
+		logger.Infof("%s ==> %-40s", lctx, binding)
 		return binding
 	}
 
@@ -391,7 +391,7 @@ func mapPathV2(binding string, context *rewriteContext) string {
 			if context.rewriteType == Request {
 				parts[0] = getHostMountPath(allPathSegments...)
 			} else {
-				logger.Warnf("%s Don't know how to map mount type %s (type: %s) for response ", lctx, parts[0], mntType)
+				logger.Infof("%s Don't know how to map mount type %s (type: %s) for response ", lctx, parts[0], mntType)
 			}
 		}
 		s = strings.Join(parts, ":")
@@ -442,7 +442,7 @@ func mapPathV2(binding string, context *rewriteContext) string {
 	}
 
 	// Log the mapping result
-	logger.Warnf("%s ==> %-40s", lctx, s)
+	logger.Infof("%s ==> %-40s", lctx, s)
 
 	return s
 }


### PR DESCRIPTION
## Summary of the Pull Request

Ensure logs generated from the windows docker proxy are propagated to the UI.

## Detailed Description of the Pull Request / Additional comments

Lower the level of some of the logs in the rewriter from `Warning` to `Info` and flow the logs.
