### PR TITLE
Bump docker binaries versions (docker: `28.2.2`, compose: `2.36.2`, buildx: `0.24.0`)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,9 +25,9 @@ on:
   workflow_dispatch:
 
 env:
-  DOCKER_VERSION: "26.1.4"
-  DOCKER_COMPOSE_VERSION: "v2.27.1"
-  DOCKER_BUILDX_VERSION: "v0.15.0"
+  DOCKER_VERSION: "28.2.2"
+  DOCKER_COMPOSE_VERSION: "v2.36.2"
+  DOCKER_BUILDX_VERSION: "v0.24.0"
   GO_VERSION: "1.22"
   GO_DNSMASQ: "1.0.7"
   REGISTRY: ghcr.io
@@ -35,13 +35,13 @@ env:
   # for templated expressions!
   # See also: https://github.com/orgs/community/discussions/25768
   # org
-  GITHUB_REPOSITORY_OWNER_LC:   
+  GITHUB_REPOSITORY_OWNER_LC: ''  
   # org/repo
-  GITHUB_REPOSITORY_LC:   
+  GITHUB_REPOSITORY_LC: ''
   # registry/org
-  REGISTRY_BASE_IMAGE_PATH:
+  REGISTRY_BASE_IMAGE_PATH: ''
   # registry/org/repo
-  DEFAULT_FULL_IMAGE_NAME:
+  DEFAULT_FULL_IMAGE_NAME: ''
   # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"

--- a/build.ps1
+++ b/build.ps1
@@ -2,9 +2,10 @@
 # - dotnet 6.0 SDK
 # - docker
 # This script must run on Windows because the application is a Windows application.
-$DOCKER_VERSION="26.1.4"
-$DOCKER_COMPOSE_VERSION="v2.27.1"
-$DOCKER_BUILDX_VERSION="v0.15.0"
+$DOCKER_VERSION="28.2.2"
+$DOCKER_COMPOSE_VERSION="v2.36.2"
+$DOCKER_BUILDX_VERSION="v0.24.0"
+$GO_DNSMASQ="1.0.7"
 $GO_VERSION="1.22"
 function ExitOnFailure([string] $message, [string] $sha) {
     if (($LastExitCode -ne 0) -or (-not $?)) {
@@ -57,7 +58,7 @@ ExitOnFailure("Failed to download WSL Kernel MSI")
 # Download dns-forwarder (go-dnsmasq)
 docker run --rm -v "$($PWD):/src" container-desktop-tools:build sh -c "mkdir -p /src/dist/bin/"
 ExitOnFailure("Failed to download dns-forwarder")
-docker run --rm -v "$($PWD):/src" container-desktop-tools:build sh -c "curl -L -o /src/dist/bin/dns-forwarder https://github.com/janeczku/go-dnsmasq/releases/download/1.0.7/go-dnsmasq-min_linux-amd64"
+docker run --rm -v "$($PWD):/src" container-desktop-tools:build sh -c "curl -L -o /src/dist/bin/dns-forwarder https://github.com/janeczku/go-dnsmasq/releases/download/$GO_DNSMASQ/go-dnsmasq-min_linux-amd64"
 ExitOnFailure("Failed to download dns-forwarder")
 # Build proxy for Windows and Linux and copy to /dist
 docker run --rm -v "go-packages-cache:/go/pkg/mod" -v "$($PWD):/go/src" -w /go/src/cmd/container-desktop-proxy -e CGO_ENABLED=0 -e GOOS=windows -e GOARCH=amd64 golang:$GO_VERSION go build -v -o /go/src/dist/container-desktop-proxy-windows-amd64.exe


### PR DESCRIPTION
## Summary of the Pull Request
Update docker (and related tooling) to the latest version.

## Detailed Description of the Pull Request / Additional comments

The core motivation is to have a version of the docker client that does
not attempt to mutate/rewrite the config
(https://github.com/docker/cli/pull/5553).

This is in preparation of a future enhancement to share the same client
configuration of the windows host and to provide a seamless experience.
This could include also the auth via credential helpers running on the
host (e.g. a basic scenario is to at least use the windows credential
manager to avoid storing static credentials in plain in the config file).

I  did not push anything yet because i am waiting to see if https://github.com/docker/cli/pull/5948 
get merged as it would probably provide a better and simpler out of the 
box experience.